### PR TITLE
fix Delta.push assertion

### DIFF
--- a/lib/quill_delta.dart
+++ b/lib/quill_delta.dart
@@ -337,8 +337,8 @@ class Delta {
 
       if (lastOp.isDelete && operation.isInsert) {
         index -= 1; // Always insert before deleting
-        lastOp = (index > 0) ? _operations.elementAt(index - 1) : null;
-        if (lastOp == null) {
+        var nLastOp = (index > 0) ? _operations.elementAt(index - 1) : null;
+        if (nLastOp == null) {
           _operations.insert(0, operation);
           return;
         }

--- a/test/quill_delta_test.dart
+++ b/test/quill_delta_test.dart
@@ -423,8 +423,18 @@ void main() {
           ..insert('\n', ul);
         expect(result, expected);
       });
-    });
 
+      test('consequent deletes and inserts', () {
+        final doc = new Delta()..insert('YOLOYOLO');
+        final change = new Delta()
+          ..insert('YATA')
+          ..delete(4)
+          ..insert('YATA');
+        final result = doc.compose(change);
+        final expected = new Delta()..insert('YATAYATAYOLO');
+        expect(result, expected);
+      });
+    });
     group('compose', () {
       // ==== insert combinations ====
 


### PR DESCRIPTION
this was failing when doing:
insert, delete, insert

```bash
$ pub run test                                                                                                                                                                         
00:01 +50 -1: test/quill_delta_test.dart: Delta push consequent deletes and inserts [E]                                                                                                      
  'package:quill_delta/quill_delta.dart': Failed assertion: line 310 pos 12: 'operation != null && last.key == operation.key': is not true.
  dart:core                                    _AssertionError._throwNew
  package:quill_delta/quill_delta.dart 310:12  Delta._mergeWithTail
  package:quill_delta/quill_delta.dart 349:11  Delta.push
  package:quill_delta/quill_delta.dart 298:5   Delta.insert
  test/quill_delta_test.dart 432:13            main.<fn>.<fn>.<fn>
```