### PR TITLE
Fix attributes comparison for operations

### DIFF
--- a/lib/quill_delta.dart
+++ b/lib/quill_delta.dart
@@ -9,10 +9,7 @@ import 'dart:math' as math;
 import 'package:collection/collection.dart';
 import 'package:quiver_hashcode/hashcode.dart';
 
-const _attributeEquality = MapEquality<String, dynamic>(
-  keys: DefaultEquality<String>(),
-  values: DefaultEquality(),
-);
+const _attributeEquality = DeepCollectionEquality();
 
 /// Operation performed on a rich-text document.
 class Operation {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: quill_delta
 description: Simple and expressive format for describing rich-text content created for Quill.js editor. This package is unofficial port to Dart from JavaScript.
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/pulyaevskiy/quill-delta-dart
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
 

--- a/test/quill_delta_test.dart
+++ b/test/quill_delta_test.dart
@@ -219,6 +219,22 @@ void main() {
       attrs['b'] = null;
       expect(op.attributes, {'b': true});
     });
+
+    test('attributes operator== simple', () {
+      var op1 = Operation.insert('\n', {'b': true});
+      var op2 = Operation.insert('\n', {'b': true});
+      expect(op1 == op2, true);
+    });
+
+    test('attributes operator== complex', () {
+      var op1 = Operation.insert('\n', {
+        'b': {'c': 'd'}
+      });
+      var op2 = Operation.insert('\n', {
+        'b': {'c': 'd'}
+      });
+      expect(op1 == op2, true);
+    });
   });
 
   group('Delta', () {


### PR DESCRIPTION
use deep equality for the case when attribute values are maps or lists.