### PR TITLE
Fix iterator for custom embed objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+* Fix iterator for custom embed objects (#14)
+
 ## 1.1.0
 
 * Changed insert operations to allow inserting dynamic object values. (#13)

--- a/lib/quill_delta.dart
+++ b/lib/quill_delta.dart
@@ -638,8 +638,11 @@ class DeltaIterator {
       final opData = op.isInsert && op.data is String
           ? op.data.substring(_currentOffset, _currentOffset + actualLength)
           : op.data;
-      final int opLength = (opData.isNotEmpty) ? opData.length : actualLength;
-      return Operation._(opKey, opLength, opData, opAttributes);
+      final opIsNotEmpty =
+          opData is String ? opData.isNotEmpty : true; // embeds are never empty
+      final opLength = opData is String ? opData.length : 1;
+      final int opActualLength = opIsNotEmpty ? opLength : actualLength;
+      return Operation._(opKey, opActualLength, opData, opAttributes);
     }
     return Operation.retain(length);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: quill_delta
 description: Simple and expressive format for describing rich-text content created for Quill.js editor. This package is unofficial port to Dart from JavaScript.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/pulyaevskiy/quill-delta-dart
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
 

--- a/test/quill_delta_test.dart
+++ b/test/quill_delta_test.dart
@@ -1145,11 +1145,12 @@ void main() {
     });
   });
 
-  group('$DeltaIterator', () {
+  group('DeltaIterator', () {
     var delta = Delta()
       ..insert('Hello', {'b': true})
       ..retain(3)
       ..insert(' world', {'i': true})
+      ..insert(Embed('hr'))
       ..delete(4);
     DeltaIterator iterator;
 
@@ -1159,7 +1160,7 @@ void main() {
 
     test('hasNext', () {
       expect(iterator.hasNext, isTrue);
-      iterator..next()..next()..next()..next();
+      iterator..next()..next()..next()..next()..next();
       expect(iterator.hasNext, isFalse);
     });
 
@@ -1169,6 +1170,8 @@ void main() {
       expect(iterator.peekLength(), 3);
       iterator.next();
       expect(iterator.peekLength(), 6);
+      iterator.next();
+      expect(iterator.peekLength(), 1);
       iterator.next();
       expect(iterator.peekLength(), 4);
       iterator.next();
@@ -1180,7 +1183,7 @@ void main() {
     });
 
     test('peekLength after EOF', () {
-      iterator.skip(18);
+      iterator.skip(19);
       expect(iterator.peekLength(), double.infinity);
     });
 
@@ -1188,6 +1191,8 @@ void main() {
       expect(iterator.isNextInsert, isTrue);
       iterator.next();
       expect(iterator.isNextRetain, isTrue);
+      iterator.next();
+      expect(iterator.isNextInsert, isTrue);
       iterator.next();
       expect(iterator.isNextInsert, isTrue);
       iterator.next();
@@ -1199,6 +1204,7 @@ void main() {
       expect(iterator.next(), Operation.insert('Hello', {'b': true}));
       expect(iterator.next(), Operation.retain(3));
       expect(iterator.next(), Operation.insert(' world', {'i': true}));
+      expect(iterator.next(), Operation.insert(Embed('hr')));
       expect(iterator.next(), Operation.delete(4));
     });
 
@@ -1209,4 +1215,23 @@ void main() {
       expect(iterator.next(2), Operation.retain(2));
     });
   });
+}
+
+class Embed {
+  final String data;
+
+  Embed(this.data);
+
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(this, other)) return true;
+    if (other is! Embed) return false;
+    final typedOther = other as Embed;
+    return typedOther.data == data;
+  }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  Map<String, dynamic> toJson() => {'data': data};
 }


### PR DESCRIPTION
Follow up fix for #13 . FYI @volser .

An error occurs when trying to call `isNotEmpty` on a custom Dart class.