### PR TITLE
Migrate to null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0-nullsafety.0
+
+* Migrated to null safety.
+
 ## 2.0.0
 
 * **Breaking change**: changed `Operation.value` type from `dynamic` to `Object` to allow better

--- a/lib/quill_delta.dart
+++ b/lib/quill_delta.dart
@@ -105,7 +105,8 @@ class Operation {
 
   /// Returns value of this operation.
   ///
-  /// For insert operations this returns text, for delete and retain - length.
+  /// For insert operations this returns the data object, for delete and
+  /// retain - length.
   dynamic get value => (key == Operation.insertKey) ? data : length;
 
   /// Returns `true` if this is a delete operation.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,13 +5,13 @@ homepage: https://github.com/pulyaevskiy/quill-delta-dart
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
   collection: ^1.14.5
-  quiver_hashcode: ^2.0.0
+  quiver: ^3.0.0-nullsafety.3
 
 dev_dependencies:
-  test: ^1.0.0
-  test_coverage: ^0.4.1
-  pedantic: ^1.9.0
+  test: ^1.16.0
+  test_coverage: ^0.5.0
+  pedantic: ^1.9.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: quill_delta
 description: Simple and expressive format for describing rich-text content created for Quill.js editor. This package is unofficial port to Dart from JavaScript.
-version: 2.0.0
+version: 3.0.0-nullsafety.0
 homepage: https://github.com/pulyaevskiy/quill-delta-dart
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
 

--- a/test/quill_delta_test.dart
+++ b/test/quill_delta_test.dart
@@ -224,7 +224,7 @@ void main() {
 
     test('attributes immutable', () {
       var op = Operation.insert('\n', {'b': true});
-      var attrs = op.attributes;
+      var attrs = op.attributes!;
       attrs['b'] = null;
       expect(op.attributes, {'b': true});
     });
@@ -1152,7 +1152,7 @@ void main() {
       ..insert(' world', {'i': true})
       ..insert(Embed('hr'))
       ..delete(4);
-    DeltaIterator iterator;
+    late DeltaIterator iterator;
 
     setUp(() {
       iterator = DeltaIterator(delta);
@@ -1226,7 +1226,7 @@ class Embed {
   bool operator ==(dynamic other) {
     if (identical(this, other)) return true;
     if (other is! Embed) return false;
-    final typedOther = other as Embed;
+    final typedOther = other;
     return typedOther.data == data;
   }
 


### PR DESCRIPTION
Hi!
I have migrated `quill-delta-dart` to null safety. The changes are mostly straightforward, as it was already clear (e.g. because of assertions) where `null` is possible and where not. But please take a look if I've missed something.
A note about the hashcode implementation: I have switched to from `quiver_hashcode` to `quiver`, because it contains the same functionality and is actually mantained (see https://github.com/QuiverDart/quiver_hashcode/pull/10#pullrequestreview-586799412for reference).