### PR TITLE
Update quiver hashcode dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Updated dependency on quiver_hashcode to main quiver package.
+
 ## 2.0.0
 
 * **Breaking change**: changed `Operation.value` type from `dynamic` to `Object` to allow better

--- a/lib/quill_delta.dart
+++ b/lib/quill_delta.dart
@@ -7,7 +7,7 @@ library quill_delta;
 import 'dart:math' as math;
 
 import 'package:collection/collection.dart';
-import 'package:quiver_hashcode/hashcode.dart';
+import 'package:quiver/core.dart';
 
 const _attributeEquality = DeepCollectionEquality();
 const _valueEquality = DeepCollectionEquality();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: quill_delta
 description: Simple and expressive format for describing rich-text content created for Quill.js editor. This package is unofficial port to Dart from JavaScript.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/pulyaevskiy/quill-delta-dart
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
 
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   collection: ^1.14.5
-  quiver_hashcode: ^2.0.0
+  quiver: ^2.0.0
 
 dev_dependencies:
   test: ^1.0.0


### PR DESCRIPTION
Development on the quiver_* subpackages has been discontinued in favour
of the main quiver package at https://github.com/google/quiver-dart. The
code itself is identical, but is more actively maintained.

This migrates to version 2.0.0 of quiver since version 3.0.0 has been
migrated to null-safety, which requires Dart SDK 2.12.0 or Flutter
2.0.0.