### PR TITLE
Offer possibility to clean up semantics

### DIFF
--- a/lib/quill_delta.dart
+++ b/lib/quill_delta.dart
@@ -474,7 +474,7 @@ class Delta {
   /// Returns a [Delta] containing differences between 2 [Delta]s
   ///
   /// Useful when one wishes to display difference between 2 documents
-  Delta diff(Delta other) {
+  Delta diff(Delta other, {bool cleanupSemantic = true}) {
     if (_operations.equals(other._operations)) {
       return Delta();
     }
@@ -495,6 +495,10 @@ class Delta {
 
     final retDelta = Delta();
     final diffResult = dmp.diff(stringThis, stringOther);
+    if (cleanupSemantic) {
+      dmp.DiffMatchPatch().diffCleanupSemantic(diffResult);
+    }
+
     final thisIter = DeltaIterator(this);
     final otherIter = DeltaIterator(other);
 

--- a/lib/quill_delta.dart
+++ b/lib/quill_delta.dart
@@ -471,7 +471,15 @@ class Delta {
     return _operations.map<T>(f);
   }
 
-  /// Returns a [Delta] containing differences between 2 [Delta]s
+  /// Returns a [Delta] containing differences between 2 [Delta]s.
+  /// If [cleanupSemantic] is `true` (default), applies the following:
+  ///
+  /// The diff of "mouse" and "sofas" is
+  ///   [delete(1), insert("s"), retain(1), delete("u"), insert("fa"), retain(1), delete(1)].
+  /// While this is the optimum diff, it is difficult for humans to understand.
+  /// Semantic cleanup rewrites the diff, expanding it into a more intelligible format.
+  /// The above example would become: [(-1, "mouse"), (1, "sofas")].
+  /// (source: https://github.com/google/diff-match-patch/wiki/API)
   ///
   /// Useful when one wishes to display difference between 2 documents
   Delta diff(Delta other, {bool cleanupSemantic = true}) {

--- a/test/quill_delta_test.dart
+++ b/test/quill_delta_test.dart
@@ -1278,6 +1278,20 @@ void main() {
           ..retain(1, {'i': true, 'bg': null})
           ..delete(3)
           ..insert('og', {'i': true});
+        expect(a.diff(b, cleanupSemantic: false), expected);
+      });
+
+      test('cleanup semantics', () {
+        final a = Delta()
+          ..insert('Bad', {'bg': 'red'})
+          ..insert('cat', {'bg': 'blue'});
+        final b = Delta()
+          ..insert('Good', {'b': true})
+          ..insert('dog', {'i': true});
+        final expected = Delta()
+          ..insert('Good', {'b': true})
+          ..insert('dog', {'i': true})
+          ..delete(6);
         expect(a.diff(b), expected);
       });
 

--- a/test/quill_delta_test.dart
+++ b/test/quill_delta_test.dart
@@ -1281,7 +1281,7 @@ void main() {
         expect(a.diff(b, cleanupSemantic: false), expected);
       });
 
-      test('cleanup semantics', () {
+      test('cleanup semantic', () {
         final a = Delta()
           ..insert('Bad', {'bg': 'red'})
           ..insert('cat', {'bg': 'blue'});


### PR DESCRIPTION
By default `diff match patch` produces the optimum diff.
Offer the option to compute a human readable diff